### PR TITLE
Add collision integral unit tests

### DIFF
--- a/src/transport/collision_integrals.rs
+++ b/src/transport/collision_integrals.rs
@@ -32,11 +32,122 @@ pub fn omega11(t_star: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::assert_relative_eq;
+
+    fn check(label: &str, got: f64, expected: f64, rtol: f64) {
+        let rel = (got - expected).abs() / expected.abs();
+        assert!(
+            rel < rtol,
+            "{label}: got {got:.10e}, expected {expected:.10e}, rel err {rel:.2e}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Polynomial arithmetic — compare against Python reference values
+    //    computed from the same Neufeld (1972) formula.  rtol = 1e-10 ensures
+    //    the Rust implementation evaluates the polynomial exactly.
+    // -----------------------------------------------------------------------
 
     #[test]
-    fn omega22_known_value() {
-        // At T* = 1.0, Ω*(2,2) ≈ 1.593 (from literature tables)
-        assert_relative_eq!(omega22(1.0), 1.593, epsilon = 0.01);
+    fn test_omega22_polynomial_values() {
+        // Reference: Python math library, identical formula
+        let cases = [
+            (0.3_f64,  2.845802516390621),
+            (0.5,      2.283064325164955),
+            (1.0,      1.592519596079362),
+            (2.0,      1.175969501456664),
+            (5.0,      0.925191231557026),
+            (10.0,     0.824862825673038),
+            (30.0,     0.700315119888241),
+            (100.0,    0.585491397311232),
+        ];
+        for (t_star, expected) in cases {
+            check(&format!("omega22 T*={t_star}"), omega22(t_star), expected, 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_omega11_polynomial_values() {
+        let cases = [
+            (0.3_f64,  2.650176361097787),
+            (0.5,      2.067477129865050),
+            (1.0,      1.440466399593360),
+            (2.0,      1.075362638995321),
+            (5.0,      0.843115644647863),
+            (10.0,     0.741854874843624),
+            (30.0,     0.623555037637060),
+            (100.0,    0.516717697672334),
+        ];
+        for (t_star, expected) in cases {
+            check(&format!("omega11 T*={t_star}"), omega11(t_star), expected, 1e-10);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Neufeld (1972) Table I cross-validation
+    //    Reference values from Hirschfelder, Curtiss & Bird (1954) Table A.3-II
+    //    as reproduced in the Neufeld polynomial fit paper.
+    //    Neufeld claims accuracy within 0.2% for 0.3 ≤ T* ≤ 100.
+    //    We test over the range where the fit is well-validated (T* ≥ 1).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_omega22_vs_neufeld_table() {
+        // (T*, Ω*(2,2) table value, tolerance)
+        let cases = [
+            (1.0_f64, 1.593_f64, 2e-3),
+            (2.0,     1.175,     2e-3),
+            (5.0,     0.9256,    2e-3),
+            (10.0,    0.8242,    2e-3),
+        ];
+        for (t_star, table_val, tol) in cases {
+            check(&format!("omega22 vs table T*={t_star}"), omega22(t_star), table_val, tol);
+        }
+    }
+
+    #[test]
+    fn test_omega11_vs_neufeld_table() {
+        let cases = [
+            (1.0_f64, 1.439_f64, 2e-3),
+            (2.0,     1.075,     2e-3),
+            (5.0,     0.8422,    2e-3),
+            (10.0,    0.7424,    2e-3),
+        ];
+        for (t_star, table_val, tol) in cases {
+            check(&format!("omega11 vs table T*={t_star}"), omega11(t_star), table_val, tol);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Sanity checks
+    // -----------------------------------------------------------------------
+
+    /// Both integrals must decrease monotonically with T*.
+    #[test]
+    fn test_monotone_decreasing() {
+        let t_stars = [0.5, 1.0, 2.0, 5.0, 10.0, 50.0];
+        for w in t_stars.windows(2) {
+            let (lo, hi) = (w[0], w[1]);
+            assert!(omega22(lo) > omega22(hi), "omega22 not decreasing at T*={lo}→{hi}");
+            assert!(omega11(lo) > omega11(hi), "omega11 not decreasing at T*={lo}→{hi}");
+        }
+    }
+
+    /// At high T*, both integrals approach ~1 from above (hard-sphere limit).
+    #[test]
+    fn test_high_t_star_limit() {
+        assert!(omega22(100.0) > 0.5 && omega22(100.0) < 1.0);
+        assert!(omega11(100.0) > 0.4 && omega11(100.0) < 1.0);
+    }
+
+    /// omega22 > omega11 for T* ≥ 1 (standard kinetic-theory result).
+    #[test]
+    fn test_omega22_gt_omega11_high_t() {
+        for &ts in &[1.0_f64, 2.0, 5.0, 10.0, 50.0] {
+            assert!(
+                omega22(ts) > omega11(ts),
+                "Expected omega22 > omega11 at T*={ts}: {} vs {}",
+                omega22(ts), omega11(ts)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace the single loose epsilon test with 7 targeted unit tests for `omega11` and `omega22`
- Polynomial arithmetic validation vs Python reference (rtol=1e-10) at 8 T* points each
- Cross-validation vs Neufeld (1972) Table I for T*=1–10 within the paper's stated 0.2% accuracy
- Sanity checks: monotone decreasing, high-T* limit (~1), omega22 > omega11 for T*≥1

## Test plan

- [x] `cargo test transport::collision_integrals` — 7 tests pass

Closes #5