### PR TITLE
Add transport property unit tests and fix binary diffusion bug

### DIFF
--- a/src/transport/mixture.rs
+++ b/src/transport/mixture.rs
@@ -79,6 +79,49 @@ pub fn mixture_diffusion_coefficients(
     dkm
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chemistry::parser::cantera_yaml::parse_file;
+
+    fn h2o2_mech() -> Mechanism {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        parse_file(&format!("{manifest}/data/h2o2.yaml")).expect("parse h2o2.yaml")
+    }
+
+    fn check(label: &str, got: f64, expected: f64, rtol: f64) {
+        let rel = (got - expected).abs() / expected.abs();
+        assert!(rel < rtol, "{label}: got {got:.6e}, expected {expected:.6e}, rel err {rel:.2e}");
+    }
+
+    fn air_mole_fractions(mech: &Mechanism) -> Vec<f64> {
+        let nk = mech.n_species();
+        let mut x = vec![0.0_f64; nk];
+        x[mech.species_index("O2").unwrap()] = 0.21;
+        x[mech.species_index("N2").unwrap()] = 0.79;
+        x
+    }
+
+    // -----------------------------------------------------------------------
+    // Wilke mixture viscosity for air (O2:0.21, N2:0.79 mole fractions)
+    // Reference: Cantera 3.1.0 (same h2o2.yaml transport parameters).
+    // Residual ~0.06% vs Cantera; 0.5% tolerance is ample.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_wilke_air_300k() {
+        let mech = h2o2_mech();
+        let x = air_mole_fractions(&mech);
+        check("mu_air 300K", mixture_viscosity(&mech, &x, 300.0), 1.863048267765e-5, 5e-3);
+    }
+
+    #[test]
+    fn test_wilke_air_1000k() {
+        let mech = h2o2_mech();
+        let x = air_mole_fractions(&mech);
+        check("mu_air 1000K", mixture_viscosity(&mech, &x, 1000.0), 4.285066600992e-5, 5e-3);
+    }
+}
+
 /// Convert mass fractions to mole fractions.
 pub fn mass_to_mole_fractions(mech: &Mechanism, y: &[f64]) -> Vec<f64> {
     let w_mean = mean_molecular_weight(&mech.species, y);

--- a/src/transport/species_props.rs
+++ b/src/transport/species_props.rs
@@ -26,6 +26,63 @@ pub fn thermal_conductivity(species: &Species, mu_k: f64, cp_k: f64, t: f64) -> 
     mu_k * (cp_k + 1.25 * R_UNIVERSAL / species.molecular_weight)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chemistry::parser::cantera_yaml::parse_file;
+
+    fn h2o2_mech() -> crate::chemistry::mechanism::Mechanism {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        parse_file(&format!("{manifest}/data/h2o2.yaml")).expect("parse h2o2.yaml")
+    }
+
+    fn check(label: &str, got: f64, expected: f64, rtol: f64) {
+        let rel = (got - expected).abs() / expected.abs();
+        assert!(rel < rtol, "{label}: got {got:.6e}, expected {expected:.6e}, rel err {rel:.2e}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Viscosity — Chapman-Enskog, Neufeld Ω*(2,2)
+    // Reference: Cantera 3.1.0 (same h2o2.yaml transport parameters).
+    // Residual ~0.06% from Cantera's use of a bilinear-interpolation table
+    // vs our Neufeld polynomial; 0.5% tolerance is ample.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_viscosity_n2_300k() {
+        let mech = h2o2_mech();
+        let sp = &mech.species[mech.species_index("N2").unwrap()];
+        check("mu_N2 300K", viscosity(sp, 300.0), 1.808570419229e-5, 5e-3);
+    }
+
+    #[test]
+    fn test_viscosity_n2_1000k() {
+        let mech = h2o2_mech();
+        let sp = &mech.species[mech.species_index("N2").unwrap()];
+        check("mu_N2 1000K", viscosity(sp, 1000.0), 4.149871864818e-5, 5e-3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Binary diffusion — Chapman-Enskog BSL formula, Neufeld Ω*(1,1)
+    // D_H2N2 in the dilute limit (X_H2 → 0) compared against
+    // Cantera mix_diff_coeffs with X_H2=0.001, X_N2=0.999.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_binary_diffusion_h2n2_300k() {
+        let mech = h2o2_mech();
+        let h2 = &mech.species[mech.species_index("H2").unwrap()];
+        let n2 = &mech.species[mech.species_index("N2").unwrap()];
+        check("D_H2N2 300K", binary_diffusion(h2, n2, 300.0, 101325.0), 7.796992738673e-5, 5e-3);
+    }
+
+    #[test]
+    fn test_binary_diffusion_h2n2_1000k() {
+        let mech = h2o2_mech();
+        let h2 = &mech.species[mech.species_index("H2").unwrap()];
+        let n2 = &mech.species[mech.species_index("N2").unwrap()];
+        check("D_H2N2 1000K", binary_diffusion(h2, n2, 1000.0, 101325.0), 5.856224715919e-4, 5e-3);
+    }
+}
+
 /// Binary diffusion coefficient Dij [m²/s] between species i and j.
 /// Dij = 3/(16·n) * sqrt(2·π·kbT / (μij)) / (π·σij²·Ω*(1,1))
 /// Simplified: Dij = 2.6280e-5 * T^1.5 / (P * σij² * Ω*(1,1) * sqrt(Wij))
@@ -42,7 +99,8 @@ pub fn binary_diffusion(sp_i: &Species, sp_j: &Species, t: f64, pressure: f64) -
 
     // Pressure in atm for the standard formula
     let p_atm = pressure / 101325.0;
-    // Dij [cm²/s] = 1.858e-3 * T^1.5 / (P_atm * σij² * Ω*(1,1) * sqrt(Wij))
-    let d_cm2_s = 1.858e-3 * t.powf(1.5) / (p_atm * sigma_ij.powi(2) * om11 * w_ij.sqrt());
+    // BSL formula: Dij [cm²/s] = 1.858e-3 * T^1.5 * sqrt(1/Wi + 1/Wj) / (P_atm * σij² * Ω*(1,1))
+    // Equivalently: 1.858e-3 * sqrt(2/Wij) = 2.6280e-3 / sqrt(Wij)
+    let d_cm2_s = 2.6280e-3 * t.powf(1.5) / (p_atm * sigma_ij.powi(2) * om11 * w_ij.sqrt());
     d_cm2_s * 1e-4 // cm²/s → m²/s
 }


### PR DESCRIPTION
## Summary

- Fix `binary_diffusion`: the BSL Chapman-Enskog constant was `1.858e-3` but should be `2.6280e-3` (= `1.858e-3 × √2`). Without this factor, D was underestimated by ~29%. Now agrees with Cantera 3.1.0 within 0.2%.
- Add 4 tests in `species_props.rs`: μ_N2 at 300K/1000K, D_H2N2 at 300K/1000K (vs Cantera, rtol=0.5%)
- Add 2 tests in `mixture.rs`: Wilke mixture viscosity for air (O2:N2=21:79) at 300K/1000K (vs Cantera, rtol=0.5%)

## Test plan

- [x] `cargo test transport` — 13 tests pass (6 new + 7 from #5)

Closes #6