### PR TITLE
Fix flame residual correctness

### DIFF
--- a/src/flame/jacobian.rs
+++ b/src/flame/jacobian.rs
@@ -37,7 +37,7 @@ pub fn numerical_jacobian(
         let x_j = x[j];
         let h = eps_rel * x_j.abs().max(eps_abs);
         x_pert[j] = x_j + h;
-        eval_residual(&x_pert, &mut f_pert, mech, grid, config);
+        eval_residual(&x_pert, &mut f_pert, mech, grid, config, None, 0.0);
 
         // Only fill within the band
         let row_min = j.saturating_sub(ku);

--- a/src/flame/residual.rs
+++ b/src/flame/residual.rs
@@ -4,18 +4,16 @@
 ///
 /// Interior points j = 1 … J-2:
 ///   Species k (k = 0 … K-2):
-///     F_yk = M * (Yk_j - Yk_{j-1})/dz_m  -  (jk_j - jk_{j-1}) / dz_av  -  ωk * Wk
-///   Species K-1: closure  F_yK = 1 - ΣYk - Y_{K,j}   or same as others with correction vel.
+///     F_yk = M * (Yk_j - Yk_{j-1})/dz_m  +  (jk_{j-1/2} - jk_{j-3/2}) / dz_av  -  ωk * Wk
+///   Species K-1: sum closure  F_yK = ΣYk - 1
 ///   Energy:
 ///     F_T = -M * cp * (T_j - T_{j-1})/dz_m
-///           + (λ_j * (T_{j+1}-T_j)/dz_p - λ_{j-1} * (T_j-T_{j-1})/dz_m) / dz_av
-///           - Σk jk_{j-1/2} * cpk * dT/dz (enthalpy transport term)
-///           - Σk ωk * hk * Wk               (heat release)
-///   Continuity (eigenvalue):
-///     F_M = M_j - M_{j-1}   (trivially = 0 enforces dM/dz = 0)
+///           + (λ_{j+1/2}*(T_{j+1}-T_j)/dz_p - λ_{j-1/2}*(T_j-T_{j-1})/dz_m) / dz_av
+///           - Σk jk_{j-1/2} * cpk * (T_j - T_{j-1})/dz_m    (enthalpy transport)
+///           - Σk ωk * hk                                       (heat release [W/m³])
 ///
 /// Left boundary (j = 0):
-///   F_yk = M * Yk_0 + jk_0 - M * Yku_k    (inlet flux condition)
+///   F_yk = M * (Yk_0 - Yku_k) + jk_{1/2}    (inlet flux condition)
 ///   F_T  = T_0 - T_unburned
 ///
 /// Right boundary (j = J-1):
@@ -24,6 +22,10 @@
 ///
 /// Eigenvalue closure: at the fixed point j = j_fix:
 ///   F_M = T_{j_fix} - T_fix   (replaces the trivial M equation at that point)
+///
+/// Pseudo-transient embedding (optional):
+///   When x_old and rdt = 1/dt are provided, adds rdt * (x - x_old) to all
+///   interior equations, implementing backward-Euler time-stepping.
 
 use crate::chemistry::kinetics::production_rates;
 use crate::chemistry::mechanism::Mechanism;
@@ -37,42 +39,45 @@ use crate::transport::mixture::{
 };
 
 pub struct FlameConfig {
-    pub pressure: f64,       // Pa
-    pub t_unburned: f64,     // K
+    pub pressure: f64,        // Pa
+    pub t_unburned: f64,      // K
     pub y_unburned: Vec<f64>, // mass fractions at inlet
-    pub z_fix: f64,          // position where T is pinned [m]
-    pub t_fix: f64,          // pinned temperature [K]
+    pub z_fix: f64,           // position where T is pinned [m]
+    pub t_fix: f64,           // pinned temperature [K]
 }
 
 /// Evaluate residual F(x) → rhs (length = solution_length).
+///
+/// `x_old` and `rdt` enable pseudo-transient continuation:
+///   rhs[i] += rdt * (x[i] - x_old[i])   for all interior equations.
+/// Pass `x_old = None` (and `rdt = 0.0`) for steady-state evaluation.
 pub fn eval_residual(
     x: &[f64],
     rhs: &mut [f64],
     mech: &Mechanism,
     grid: &Grid,
     config: &FlameConfig,
+    x_old: Option<&[f64]>,
+    rdt: f64,
 ) {
     let nk = mech.n_species();
     let nj = grid.n_points();
     let nv = natj(mech);
     let p = config.pressure;
 
-    // Zero out residual
     rhs.iter_mut().for_each(|r| *r = 0.0);
 
     let state = FlameState::new(x, mech, grid);
     let m = state.mass_flux();
 
-    // Pre-compute midpoint transport properties: λ[j] and Dk[k][j] at interval midpoints
-    // (between j and j+1), indexed 0..nj-1.
     let dz = grid.dz();
 
-    let mut lambda_mid = vec![0.0_f64; nj - 1]; // thermal conductivity at midpoints
-    let mut dk_mid = vec![vec![0.0_f64; nj - 1]; nk]; // diffusion coeff at midpoints
+    // Pre-compute midpoint transport: λ[j] and Dk[k][j] at interval j (between j and j+1)
+    let mut lambda_mid = vec![0.0_f64; nj - 1];
+    let mut dk_mid = vec![vec![0.0_f64; nj - 1]; nk];
     let mut rho_mid = vec![0.0_f64; nj - 1];
 
     for j in 0..nj - 1 {
-        // Average T and Y between j and j+1
         let t_av = 0.5 * (state.temperature(j) + state.temperature(j + 1));
         let y_av: Vec<f64> = (0..nk)
             .map(|k| 0.5 * (state.species(k, j) + state.species(k, j + 1)))
@@ -87,12 +92,9 @@ pub fn eval_residual(
         }
     }
 
-    // Compute diffusion fluxes jk = ρ*Yk*Vk [kg/(m²·s)] at each midpoint j (between j and j+1).
-    // Mixture-averaged with correction velocity:
-    //   jk_raw = -ρ * Dk * dYk/dz
-    //   Vc = Σk jk_raw  (correction to ensure Σjk = 0)
-    //   jk = jk_raw - Yk * ρ * Vc / ... (correction velocity term)
-    let mut jk_mid = vec![vec![0.0_f64; nj - 1]; nk]; // jk[k][j]
+    // Diffusion fluxes jk [kg/(m²·s)] at each midpoint j (between j and j+1).
+    // Mixture-averaged with correction velocity to enforce Σjk = 0.
+    let mut jk_mid = vec![vec![0.0_f64; nj - 1]; nk];
 
     for j in 0..nj - 1 {
         let mut jk_raw = vec![0.0_f64; nk];
@@ -102,8 +104,6 @@ pub fn eval_residual(
             jk_raw[k] = -rho_mid[j] * dk_mid[k][j] * dy_dz;
             sum_jk += jk_raw[k];
         }
-        // Correction velocity: Vc such that Σ(jk + Yk * ρ * Vc) = 0
-        // Applied as: jk_corrected = jk_raw - Yk_av * sum_jk
         for k in 0..nk {
             let yk_av = 0.5 * (state.species(k, j) + state.species(k, j + 1));
             jk_mid[k][j] = jk_raw[k] - yk_av * sum_jk;
@@ -113,87 +113,79 @@ pub fn eval_residual(
     // --- Left boundary (j = 0) ---
     {
         let j = 0;
-        let t_j = state.temperature(j);
-        rhs[idx_t(nv, j)] = t_j - config.t_unburned;
+        rhs[idx_t(nv, j)] = state.temperature(j) - config.t_unburned;
 
-        let mut sum_y = 0.0_f64;
-        for k in 0..nk - 1 {
+        for k in 0..nk {
             let yk = state.species(k, j);
-            // Inlet flux BC: M * Yk - jk_{0} = M * Yku_k → F = M*(Yk - Yku) + jk
-            // For a no-diffusion-at-inlet approximation: F = Yk - Yku
-            rhs[idx_y(nv, j, k)] = yk - config.y_unburned[k];
-            sum_y += yk;
+            // Inlet flux BC: M*(Yk - Yku) + jk_{1/2} = 0
+            rhs[idx_y(nv, j, k)] = m * (yk - config.y_unburned[k]) + jk_mid[k][0];
         }
-        // Last species: sum constraint
-        rhs[idx_y(nv, j, nk - 1)] = state.species(nk - 1, j) - config.y_unburned[nk - 1];
     }
 
     // --- Interior points j = 1 … J-2 ---
     let j_fix = find_fixed_point(grid, config.z_fix);
 
     for j in 1..nj - 1 {
-        let t_j = state.temperature(j);
+        let t_j   = state.temperature(j);
         let t_jm1 = state.temperature(j - 1);
         let t_jp1 = state.temperature(j + 1);
-        let dz_m = dz[j - 1];
-        let dz_p = dz[j];
+        let dz_m = dz[j - 1]; // dz between j-1 and j
+        let dz_p = dz[j];     // dz between j and j+1
         let dz_av = 0.5 * (dz_m + dz_p);
 
         let y_j: Vec<f64> = (0..nk).map(|k| state.species(k, j)).collect();
         let w_mean = mean_molecular_weight(&mech.species, &y_j);
         let rho_j = density(p, t_j, w_mean);
-        let x_j = mass_to_mole_fractions(mech, &y_j);
 
-        // Chemical production rates ωk [mol/(m³·s)]
+        // Chemical production rates: concentrations in mol/cm³ (CGS, consistent with A values)
         let conc: Vec<f64> = (0..nk)
-            .map(|k| rho_j * y_j[k] / mech.species[k].molecular_weight)
+            .map(|k| rho_j * y_j[k] / mech.species[k].molecular_weight * 1e-6)
             .collect();
-        let wdot = production_rates(mech, t_j, &conc, p);
+        let wdot = production_rates(mech, t_j, &conc, p); // mol/(cm³·s)
 
         // Species equations
-        let mut sum_y = 0.0_f64;
+        let mut sum_yk = 0.0_f64;
         for k in 0..nk - 1 {
-            let yk_j  = state.species(k, j);
+            let yk_j   = state.species(k, j);
             let yk_jm1 = state.species(k, j - 1);
             let convec = m * (yk_j - yk_jm1) / dz_m;
             let diffus = (jk_mid[k][j] - jk_mid[k][j - 1]) / dz_av;
-            let source = wdot[k] * mech.species[k].molecular_weight;
+            // wdot mol/(cm³·s) × 1e6 → mol/(m³·s) × Wk → kg/(m³·s)
+            let source = wdot[k] * mech.species[k].molecular_weight * 1e6;
             rhs[idx_y(nv, j, k)] = convec + diffus - source;
-            sum_y += yk_j;
+            sum_yk += yk_j;
         }
-        // Last species: correction velocity closure
-        rhs[idx_y(nv, j, nk - 1)] = sum_y + state.species(nk - 1, j) - 1.0;
+        // Last species: mass fraction sum closure
+        rhs[idx_y(nv, j, nk - 1)] = sum_yk + state.species(nk - 1, j) - 1.0;
 
         // Energy equation
-        let cp_j = cp_mixture(&mech.species, &y_j, t_j);
-        let lambda_j   = lambda_mid[j];      // midpoint j (between j and j+1)
-        let lambda_jm1 = lambda_mid[j - 1];  // midpoint j-1 (between j-1 and j)
+        let cp_j       = cp_mixture(&mech.species, &y_j, t_j);
+        let lambda_j   = lambda_mid[j];      // midpoint between j and j+1
+        let lambda_jm1 = lambda_mid[j - 1];  // midpoint between j-1 and j
 
         let conduction = (lambda_j * (t_jp1 - t_j) / dz_p
             - lambda_jm1 * (t_j - t_jm1) / dz_m) / dz_av;
 
-        // Enthalpy transport: Σk jk_{av} * cpk * dT/dz
-        let dt_dz = (t_jp1 - t_jm1) / (dz_m + dz_p);
+        // Enthalpy transport: Σk jk_{j-1/2} * cpk * dT/dz_{j-1/2}
+        // Use left midpoint flux jk_mid[k][j-1] and upwind temperature gradient.
+        let dt_dz_m = (t_j - t_jm1) / dz_m;
         let mut enthalpy_transport = 0.0_f64;
         for k in 0..nk {
-            let jk_av = 0.5 * (jk_mid[k][j].min_or(j, &jk_mid) + jk_mid[k][j - 1]);
             let cp_k = cp_species(&mech.species[k], t_j);
-            enthalpy_transport += jk_av * cp_k * dt_dz;
+            enthalpy_transport += jk_mid[k][j - 1] * cp_k * dt_dz_m;
         }
 
-        // Heat release: Σk ωk * hk * Wk  (note hk in J/mol, Wk in kg/mol)
+        // Heat release: Σk ωk * hk [W/m³]
+        // wdot mol/(cm³·s) × 1e6 → mol/(m³·s); hk J/mol → W/m³
         let heat_release: f64 = (0..nk)
             .map(|k| wdot[k] * enthalpy_molar(&mech.species[k], t_j))
-            .sum();
+            .sum::<f64>() * 1e6;
 
-        // Residual: ρ*cp*∂T/∂t = ...  but steady state → F_T = 0
-        // Written as: 0 = -M*cp*dT/dz_upwind + conduction - enthalpy_transport - heat_release
         let convec_t = m * cp_j * (t_j - t_jm1) / dz_m;
         rhs[idx_t(nv, j)] = -convec_t + conduction - enthalpy_transport - heat_release;
 
-        // Continuity / eigenvalue
+        // Eigenvalue closure: fix temperature at j_fix to locate the flame
         if j == j_fix {
-            // Fix temperature to locate flame
             rhs[idx_m(nv, nj)] = t_j - config.t_fix;
         }
     }
@@ -207,9 +199,20 @@ pub fn eval_residual(
         }
     }
 
-    // Mass flux equations: dM/dz = 0 → M_j = M_{j-1} (except at j_fix)
-    // The global M is the last unknown; individual continuity eqs are trivially satisfied.
-    // (This simplified layout uses a single M; see DESIGN.md section 3.1 for discussion.)
+    // --- Pseudo-transient embedding ---
+    // Adds rdt*(x - x_old) to all interior variable equations.
+    if let Some(x_old) = x_old {
+        if rdt > 0.0 {
+            for j in 1..nj - 1 {
+                let it = idx_t(nv, j);
+                rhs[it] += rdt * (x[it] - x_old[it]);
+                for k in 0..nk {
+                    let iy = idx_y(nv, j, k);
+                    rhs[iy] += rdt * (x[iy] - x_old[iy]);
+                }
+            }
+        }
+    }
 }
 
 /// Find the grid index closest to z_fix.
@@ -222,10 +225,107 @@ fn find_fixed_point(grid: &Grid, z_fix: f64) -> usize {
         .unwrap_or(grid.n_points() / 2)
 }
 
-// Helper trait to avoid borrow issues in inner loop
-trait MinOr {
-    fn min_or(&self, j: usize, full: &Vec<Vec<f64>>) -> f64;
-}
-impl MinOr for f64 {
-    fn min_or(&self, _j: usize, _full: &Vec<Vec<f64>>) -> f64 { *self }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chemistry::parser::cantera_yaml::parse_file;
+    use crate::flame::domain::Grid;
+    use crate::flame::state::{idx_m, idx_t, idx_y, natj, solution_length};
+
+    fn h2o2_mech() -> Mechanism {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        parse_file(&format!("{manifest}/data/h2o2.yaml")).expect("parse h2o2.yaml")
+    }
+
+    // -----------------------------------------------------------------------
+    // Residual ≈ 0 for a uniform steady-state profile with no reactions.
+    //
+    // State: T = 1000 K (uniform), Y_N2 = 1 (all other species = 0),
+    //        M = 0.2 kg/(m²·s).
+    //
+    // Why this should give F ≈ 0:
+    //   - Uniform T and Y → all convection and diffusion terms = 0
+    //   - N2 is not a reactant/product in h2o2.yaml → ωk = 0 for all k
+    //   - Left BC: M*(Y_N2 - 1) + jk_0 = 0 + 0 = 0
+    //   - Right BC: zero gradient trivially satisfied
+    //   - Eigenvalue: T(j_fix) - T_fix = 0
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_residual_zero_for_uniform_n2() {
+        let mech = h2o2_mech();
+        let nk = mech.n_species();
+        let nj = 6;
+        let nv = natj(&mech);
+        let grid = Grid::uniform(0.02, nj);
+
+        let n2_idx = mech.species_index("N2").unwrap();
+
+        // Build solution vector: T = 1000 K, Y_N2 = 1, M = 0.2
+        let mut x = vec![0.0_f64; solution_length(&mech, nj)];
+        for j in 0..nj {
+            x[idx_t(nv, j)] = 1000.0;
+            x[idx_y(nv, j, n2_idx)] = 1.0;
+        }
+        x[idx_m(nv, nj)] = 0.2;
+
+        // y_unburned = pure N2 at 1000 K; z_fix and t_fix consistent with profile
+        let mut y_unburned = vec![0.0_f64; nk];
+        y_unburned[n2_idx] = 1.0;
+        let config = FlameConfig {
+            pressure: 101325.0,
+            t_unburned: 1000.0,
+            y_unburned,
+            z_fix: grid.z[nj / 2],
+            t_fix: 1000.0,
+        };
+
+        let mut rhs = vec![0.0_f64; solution_length(&mech, nj)];
+        eval_residual(&x, &mut rhs, &mech, &grid, &config, None, 0.0);
+
+        let max_abs = rhs.iter().cloned().fold(0.0_f64, f64::max);
+        assert!(
+            max_abs < 1e-8,
+            "Max |F| = {max_abs:.3e} (expected < 1e-8 for uniform steady N2 profile)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pseudo-transient term: for x_old = x, rdt * (x - x_old) = 0.
+    // So residual with pseudo-transient should equal steady-state residual.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_pseudo_transient_zero_when_x_eq_x_old() {
+        let mech = h2o2_mech();
+        let nk = mech.n_species();
+        let nj = 6;
+        let nv = natj(&mech);
+        let grid = Grid::uniform(0.02, nj);
+        let n2_idx = mech.species_index("N2").unwrap();
+
+        let mut x = vec![0.0_f64; solution_length(&mech, nj)];
+        for j in 0..nj {
+            x[idx_t(nv, j)] = 1000.0;
+            x[idx_y(nv, j, n2_idx)] = 1.0;
+        }
+        x[idx_m(nv, nj)] = 0.2;
+
+        let mut y_unburned = vec![0.0_f64; nk];
+        y_unburned[n2_idx] = 1.0;
+        let config = FlameConfig {
+            pressure: 101325.0,
+            t_unburned: 1000.0,
+            y_unburned,
+            z_fix: grid.z[nj / 2],
+            t_fix: 1000.0,
+        };
+
+        let mut rhs_steady = vec![0.0_f64; solution_length(&mech, nj)];
+        let mut rhs_pt     = vec![0.0_f64; solution_length(&mech, nj)];
+        eval_residual(&x, &mut rhs_steady, &mech, &grid, &config, None, 0.0);
+        eval_residual(&x, &mut rhs_pt,     &mech, &grid, &config, Some(&x.clone()), 1e4);
+
+        for (a, b) in rhs_steady.iter().zip(rhs_pt.iter()) {
+            assert!((a - b).abs() < 1e-15, "PT residual differs from steady: {a:.3e} vs {b:.3e}");
+        }
+    }
 }

--- a/src/flame/state.rs
+++ b/src/flame/state.rs
@@ -57,7 +57,7 @@ impl<'a> FlameState<'a> {
     }
 
     pub fn species(&self, k: usize, j: usize) -> f64 {
-        self.x[idx_y(self.natj, k, j)]
+        self.x[idx_y(self.natj, j, k)]
     }
 
     pub fn mass_flux(&self) -> f64 {

--- a/src/solver/newton.rs
+++ b/src/solver/newton.rs
@@ -39,7 +39,7 @@ pub fn solve(
     let mut jac_age = newton.max_jac_age + 1; // force Jacobian evaluation on first iteration
 
     for iter in 0..newton.max_iter {
-        eval_residual(x, &mut f, mech, grid, config);
+        eval_residual(x, &mut f, mech, grid, config, None, 0.0);
 
         let norm_f = norm2(&f);
         eprintln!("Newton iter {iter:3}: ‖F‖ = {norm_f:.3e}");
@@ -92,7 +92,7 @@ fn line_search(
         for i in 0..n {
             x_new[i] = x[i] + alpha * step[i];
         }
-        eval_residual(&x_new, &mut f_new, mech, grid, config);
+        eval_residual(&x_new, &mut f_new, mech, grid, config, None, 0.0);
         if norm2(&f_new) < norm_f0 {
             return Ok(alpha);
         }

--- a/src/solver/pseudo_transient.rs
+++ b/src/solver/pseudo_transient.rs
@@ -43,7 +43,7 @@ pub fn step(
     let mut dt = pt.dt_initial;
 
     for step_idx in 0..pt.n_steps {
-        eval_residual(x, &mut f, mech, grid, config);
+        eval_residual(x, &mut f, mech, grid, config, None, 0.0);
         let norm_f = norm2(&f);
 
         eprintln!("PT step {step_idx:4}: ‖F‖ = {norm_f:.3e},  dt = {dt:.2e}");


### PR DESCRIPTION
## Summary

- **`state.rs`**: `species(k, j)` was calling `idx_y(natj, k, j)` (k and j swapped) — all species reads were from wrong indices
- **Left BC**: `Yk - Yku` → proper inlet flux form `M*(Yk - Yku) + jk_{1/2}`
- **Enthalpy transport**: was using central dT/dz and average of both midpoint fluxes; fixed to use `jk_mid[k][j-1]` (left midpoint) with upwind `(T_j - T_{j-1})/dz_m`, matching PREMIX
- **Concentration units**: concentrations were in mol/m³ but kinetics expects mol/cm³; added ×1e-6 conversion and ×1e6 on wdot output
- **Pseudo-transient**: added `x_old: Option<&[f64]>` and `rdt: f64` parameters; when provided, adds `rdt*(x-x_old)` to all interior equations
- **Cleanup**: removed unused `sum_y`, unused `x_j`, and `MinOr` trait hack

## Test plan

- [x] `cargo test flame::residual` — 2 new tests pass (uniform N2 gives |F|<1e-8; PT with x_old=x unchanged)
- [x] `cargo test` — all 40 tests pass

Closes #7