### PR TITLE
Fix correction velocity: use left-cell Yk

### DIFF
--- a/src/flame/residual.rs
+++ b/src/flame/residual.rs
@@ -105,8 +105,8 @@ pub fn eval_residual(
             sum_jk += jk_raw[k];
         }
         for k in 0..nk {
-            let yk_av = 0.5 * (state.species(k, j) + state.species(k, j + 1));
-            jk_mid[k][j] = jk_raw[k] - yk_av * sum_jk;
+            // Use left-cell Yk, consistent with the upwind convection scheme.
+            jk_mid[k][j] = jk_raw[k] - state.species(k, j) * sum_jk;
         }
     }
 


### PR DESCRIPTION
## Summary

The diffusion flux correction velocity used a midpoint-averaged mass fraction, inconsistent with the upwind convection scheme. Changed to the left-cell value:

\`\`\`rust
// Before:
let yk_av = 0.5 * (state.species(k, j) + state.species(k, j + 1));
jk_mid[k][j] = jk_raw[k] - yk_av * sum_jk;

// After:
jk_mid[k][j] = jk_raw[k] - state.species(k, j) * sum_jk;
\`\`\`

Impact is O(dz²) — small except near steep composition gradients in the reaction zone.

Closes #30