### PR TITLE
Fix pseudo-transient x_old tracking and add unit tests

### DIFF
--- a/src/solver/pseudo_transient.rs
+++ b/src/solver/pseudo_transient.rs
@@ -1,8 +1,9 @@
 /// Pseudo-transient continuation (time-stepping) to get Newton in the basin of attraction.
 ///
-/// Adds a transient term (x - x_old)/dt to the residual:
-///   F_transient(x) = F_steady(x) + (x - x_old) / dt
-/// Solving this converges x toward the steady-state solution as dt → ∞.
+/// At each step, solves the implicit system:
+///   (J_steady + I/dt) · Δx = -F_steady(x_old)
+/// where x_old is the state at the beginning of the step.  This is equivalent to
+/// backward-Euler integration of dx/dt = -F_steady(x) starting from x_old.
 
 use anyhow::Result;
 use crate::chemistry::mechanism::Mechanism;
@@ -43,7 +44,13 @@ pub fn step(
     let mut dt = pt.dt_initial;
 
     for step_idx in 0..pt.n_steps {
-        eval_residual(x, &mut f, mech, grid, config, None, 0.0);
+        // Save x_old explicitly — the transient term is (x - x_old)/dt.
+        // Evaluating F_pt at x = x_old gives F_steady(x_old) (PT term = 0),
+        // which is the correct RHS for the backward-Euler linear system.
+        let x_old = x.clone();
+        let rdt = 1.0 / dt;
+
+        eval_residual(x, &mut f, mech, grid, config, Some(&x_old), rdt);
         let norm_f = norm2(&f);
 
         eprintln!("PT step {step_idx:4}: ‖F‖ = {norm_f:.3e},  dt = {dt:.2e}");
@@ -53,14 +60,15 @@ pub fn step(
             break;
         }
 
-        // Build Jacobian of transient system: J_pt = J_steady + I/dt
+        // Jacobian of PT system: J_pt = J_steady + I/dt.
+        // numerical_jacobian uses F_steady, so we add I/dt manually.
         let mut jac = numerical_jacobian(x, &f, mech, grid, config);
         for i in 0..n {
-            let val = jac.get(i, i) + 1.0 / dt;
+            let val = jac.get(i, i) + rdt;
             jac.set(i, i, val);
         }
 
-        // RHS = -F_steady  (transient term: (x - x_old)/dt = 0 initially)
+        // RHS = -F_pt(x_old) = -F_steady(x_old)  (PT term is zero at x = x_old).
         let mut rhs: Vec<f64> = f.iter().map(|v| -v).collect();
         jac.solve(&mut rhs)?;
 
@@ -76,4 +84,124 @@ pub fn step(
 
 fn norm2(v: &[f64]) -> f64 {
     v.iter().map(|x| x * x).sum::<f64>().sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chemistry::parser::cantera_yaml::parse_file;
+    use crate::flame::domain::Grid;
+    use crate::flame::residual::FlameConfig;
+    use crate::flame::state::{idx_m, idx_t, idx_y, natj, solution_length};
+
+    fn h2o2_mech() -> crate::chemistry::mechanism::Mechanism {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        parse_file(&format!("{manifest}/data/h2o2.yaml")).expect("parse h2o2.yaml")
+    }
+
+    // Starting from a perturbed N2 profile, PT steps should reduce the
+    // steady-state residual norm toward zero.
+    // (The +I/dt diagonal prevents zero-pivot even when J_steady is singular.)
+    #[test]
+    fn test_pseudo_transient_reduces_residual() {
+        let mech = h2o2_mech();
+        let nk = mech.n_species();
+        let nj = 6;
+        let nv = natj(&mech);
+        let grid = Grid::uniform(0.02, nj);
+        let n2_idx = mech.species_index("N2").unwrap();
+
+        // Uniform N2 profile — exact steady state.
+        let mut x = vec![0.0_f64; solution_length(&mech, nj)];
+        for j in 0..nj {
+            x[idx_t(nv, j)] = 1000.0;
+            x[idx_y(nv, j, n2_idx)] = 1.0;
+        }
+        x[idx_m(nv, nj)] = 0.2;
+
+        let mut y_unburned = vec![0.0_f64; nk];
+        y_unburned[n2_idx] = 1.0;
+        let config = FlameConfig {
+            pressure: 101325.0,
+            t_unburned: 1000.0,
+            y_unburned,
+            z_fix: grid.z[nj / 2],
+            t_fix: 1000.0,
+        };
+
+        // Perturb one interior temperature node.
+        x[idx_t(nv, nj / 2)] += 50.0;
+
+        // Measure initial steady-state residual.
+        let n = solution_length(&mech, nj);
+        let mut f_init = vec![0.0_f64; n];
+        eval_residual(&x, &mut f_init, &mech, &grid, &config, None, 0.0);
+        let norm_init = norm2(&f_init);
+
+        // Run a few PT steps (large dt to get near-Newton behaviour).
+        let pt_cfg = PseudoTransientConfig {
+            n_steps: 5,
+            dt_initial: 1e-4,
+            ..Default::default()
+        };
+        step(&mut x, &mech, &grid, &config, &pt_cfg).expect("PT must not fail");
+
+        // Measure final steady-state residual.
+        let mut f_final = vec![0.0_f64; n];
+        eval_residual(&x, &mut f_final, &mech, &grid, &config, None, 0.0);
+        let norm_final = norm2(&f_final);
+
+        assert!(
+            norm_final < norm_init,
+            "PT should reduce residual: initial {norm_init:.3e}, final {norm_final:.3e}"
+        );
+    }
+
+    // When x_old = x, F_pt(x) = F_steady(x) (transient term is zero).
+    // This is the same property verified in residual.rs but tested here
+    // through the PT solver's explicit x_old tracking.
+    #[test]
+    fn test_pseudo_transient_preserves_steady_solution() {
+        let mech = h2o2_mech();
+        let nk = mech.n_species();
+        let nj = 6;
+        let nv = natj(&mech);
+        let grid = Grid::uniform(0.02, nj);
+        let n2_idx = mech.species_index("N2").unwrap();
+
+        let mut x = vec![0.0_f64; solution_length(&mech, nj)];
+        for j in 0..nj {
+            x[idx_t(nv, j)] = 1000.0;
+            x[idx_y(nv, j, n2_idx)] = 1.0;
+        }
+        x[idx_m(nv, nj)] = 0.2;
+
+        let mut y_unburned = vec![0.0_f64; nk];
+        y_unburned[n2_idx] = 1.0;
+        let config = FlameConfig {
+            pressure: 101325.0,
+            t_unburned: 1000.0,
+            y_unburned,
+            z_fix: grid.z[nj / 2],
+            t_fix: 1000.0,
+        };
+
+        // PT on the exact steady state: ‖F‖ < 1e-3 at step 0 → exits immediately.
+        // x should not change (step = 0 because RHS ≈ 0).
+        let x_before = x.clone();
+        let pt_cfg = PseudoTransientConfig {
+            n_steps: 10,
+            dt_initial: 1e-6,
+            ..Default::default()
+        };
+        step(&mut x, &mech, &grid, &config, &pt_cfg).expect("PT must not fail");
+
+        // x should be essentially unchanged.
+        let max_delta = x.iter().zip(x_before.iter()).map(|(a, b)| (a - b).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_delta < 1e-10,
+            "PT on exact steady state should not change x (max Δ = {max_delta:.3e})"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Explicitly save `x_old = x.clone()` before each PT step
- Pass `Some(&x_old), rdt` to `eval_residual` (makes backward-Euler formulation explicit)
- Remove misleading comment "transient term: (x - x_old)/dt = 0 initially"
- Two unit tests verifying PT behavior

## Test plan
- [x] `test_pseudo_transient_reduces_residual` — PT reduces ‖F‖ from perturbed N2 state
- [x] `test_pseudo_transient_preserves_steady_solution` — PT doesn't change exact steady state
- [x] All 46 tests pass

Closes #11