### PR TITLE
Fix enthalpy transport: upwind hk differencing (matches Cantera)

### DIFF
--- a/src/flame/residual.rs
+++ b/src/flame/residual.rs
@@ -30,7 +30,7 @@
 use crate::chemistry::kinetics::production_rates;
 use crate::chemistry::mechanism::Mechanism;
 use crate::chemistry::thermo::{
-    cp_mixture, cp_species, density, enthalpy_molar, mean_molecular_weight,
+    cp_mixture, density, enthalpy_molar, mean_molecular_weight,
 };
 use crate::flame::domain::Grid;
 use crate::flame::state::{idx_m, idx_t, idx_y, natj, FlameState};
@@ -183,15 +183,19 @@ pub fn eval_residual(
         let conduction = (lambda_j * (t_jp1 - t_j) / dz_p
             - lambda_jm1 * (t_j - t_jm1) / dz_m) / dz_av;
 
-        // Enthalpy transport: Σk jk * cpk * dT/dz  evaluated at point j.
-        // Average the diffusion fluxes at the two adjacent midpoints (j-1/2 and j+1/2)
-        // for second-order accuracy, consistent with Cantera's FreeFlame formulation.
-        let dt_dz_m = (t_j - t_jm1) / dz_m;
+        // Enthalpy transport: Σk jk * dhk/dz  (matches Cantera Flow1D exactly)
+        //
+        // dhk/dz uses upwind differencing (u > 0 for free flame):
+        //   dhk/dz ≈ (hk(j) - hk(j-1)) / dz_m   [J/(kg·m)]
+        //
+        // jk averaged over adjacent midpoints (j-1/2) and (j+1/2).
         let mut enthalpy_transport = 0.0_f64;
         for k in 0..nk {
-            let cp_k = cp_species(&mech.species[k], t_j);
+            let hk_j   = enthalpy_molar(&mech.species[k], t_j)   / mech.species[k].molecular_weight;
+            let hk_jm1 = enthalpy_molar(&mech.species[k], t_jm1) / mech.species[k].molecular_weight;
+            let dhk_dz = (hk_j - hk_jm1) / dz_m;
             let jk_avg = 0.5 * (jk_mid[k][j - 1] + jk_mid[k][j]);
-            enthalpy_transport += jk_avg * cp_k * dt_dz_m;
+            enthalpy_transport += jk_avg * dhk_dz;
         }
 
         // Heat release: Σk ωk * hk [W/m³]


### PR DESCRIPTION
## Summary

Replaces the approximation `dhk/dz ≈ cpk * dT/dz` with the exact Cantera-equivalent formulation:

```rust
// Before
enthalpy_transport += jk_avg * cp_k * dt_dz_m;

// After
let dhk_dz = (hk(j) - hk(j-1)) / dz_m;   // upwind, u>0
enthalpy_transport += jk_avg * dhk_dz;
```

`hk = enthalpy_molar / Wk` [J/kg] is evaluated from the NASA polynomial at each grid point. This matches `Flow1D::grad_hk` in Cantera exactly.

## Result

Su and T_max unchanged (2.3574 m/s, 0.9% error) — the previous approximation happened to be accurate for H2/air because the flame temperature profile is smooth. The formulation is now physically correct.

## Test plan

- [x] `cargo test --lib` — 76 tests pass
- [x] E2E validation passes (Su = 2.3574 m/s, < 1.5% limit)

Closes #49